### PR TITLE
If shared.js doesn't exist then don't try to load it. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const app = express();
 const server = require('http').Server(app);
 const io = require('socket.io')(server);
 const code = fs.readFileSync('./public/server.js', 'utf8');
-const shared = fs.readFileSync('./public/shared.js', 'utf8');
+const shared = fs.existsSync('./public/shared.js') ? fs.readFileSync('./public/shared.js', 'utf8') : '';
 const storage = require('./lib/storage');
 
 let packageSize = 0;


### PR DESCRIPTION
Before this change if a submission didn't provide shared.js then the server would crash on startup. Now this file is optional.