### PR TITLE
Add Buffer class to sandbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function createSandbox() {
         clearTimeout,
         setInterval,
         clearInterval,
+        Buffer,
         storage: storage.interface,
         io: io
     };


### PR DESCRIPTION
This will allow server-side code to use the Buffer API to do base64 string parsing among other things. The client has atob/btoa to do this, but this API is not available in node.js.